### PR TITLE
Fix pipeline failing with Node20 on CentOS7

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   package:
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     container: 
       image: ghcr.io/fraunhofer-iis/libjapi_ci
       credentials:


### PR DESCRIPTION
This ist just a temporary fix: continue using Node16 for Centos7 container

A full solution would need:
- Test library on more modern OS
- Create and upload new container or rewrite actions to not use container at all -> 
- Change upload-artifacts to v4

That is mostly covered in #123 