### PR TITLE
enable tests by default and always include googletest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ if(LIBJAPI_ENABLE_TESTING)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.8.1)
+    GIT_TAG release-1.8.0)
   FetchContent_MakeAvailable(googletest)
   include(GoogleTest)
 
@@ -89,7 +89,6 @@ if(LIBJAPI_ENABLE_TESTING)
   target_include_directories(testsuite PUBLIC include/ src/
                                               ${JSONC_INCLUDE_DIRS})
 
-  # add_custom_target(run_test COMMAND testsuite DEPENDS testsuite)
   gtest_discover_tests(testsuite)
 ################################
   # Test code coverage #
@@ -97,7 +96,7 @@ if(LIBJAPI_ENABLE_TESTING)
   if(CMAKE_BUILD_TYPE MATCHES "Debug")
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
     include(${CMAKE_SOURCE_DIR}/cmake/CodeCoverage.cmake)
-    set(COVERAGE_EXCLUDES "doxydir" "/usr/include/*" "googletest/*" "test/*")
+    set(COVERAGE_EXCLUDES "doxydir" "/usr/include/*" "test/*")
     append_coverage_compiler_flags()
 
     setup_target_for_coverage_lcov(NAME coverage EXECUTABLE testsuite)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # 'cmake -DCMAKE_BUILD_TYPE=Debug ../' from build folder for debug output #
 if(NOT CMAKE_BUILD_TYPE)
-	set(CMAKE_BUILD_TYPE "Release")
+  set(CMAKE_BUILD_TYPE "Release")
 endif()
 
 file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/*)
@@ -29,12 +29,11 @@ target_include_directories(japi_objs PUBLIC include/ ${JSONC_INCLUDE_DIRS})
 set_property(TARGET japi_objs PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # set up actual libraries
-add_library(japi        SHARED $<TARGET_OBJECTS:japi_objs>)
+add_library(japi SHARED $<TARGET_OBJECTS:japi_objs>)
 add_library(japi-static STATIC $<TARGET_OBJECTS:japi_objs>)
 
-set_target_properties(japi PROPERTIES
-  PUBLIC_HEADER "${PUBLIC_HEADERS}"
-  SOVERSION ${SOVERSION})
+set_target_properties(japi PROPERTIES PUBLIC_HEADER "${PUBLIC_HEADERS}"
+                                      SOVERSION ${SOVERSION})
 
 target_link_libraries(japi PkgConfig::JSONC)
 target_link_libraries(japi-static PkgConfig::JSONC)
@@ -54,8 +53,10 @@ install(TARGETS japi
 find_package(Doxygen)
 
 if(DOXYGEN_FOUND)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxydir/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
-  add_custom_target(doc
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxydir/Doxyfile.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+  add_custom_target(
+    doc
     ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Generating API documentation with Doxygen" VERBATIM
@@ -64,59 +65,41 @@ endif(DOXYGEN_FOUND)
 
 ################################
 # Create unit test excecutable #
-find_package(GTest QUIET)
-if(${GTest_FOUND})
-	# Gtest on System Installed
-	message("GTest: Installed using GTest")
-	include(GoogleTest)
-else()
+option(LIBJAPI_ENABLE_TESTING "Enable testing with googletest" ON)
+if(LIBJAPI_ENABLE_TESTING)
+  enable_testing()
+
   # Include GoogleTest in the project
   include(FetchContent)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.8.1
-  )
+    GIT_TAG release-1.8.1)
   FetchContent_MakeAvailable(googletest)
   include(GoogleTest)
-endif()
-    
-# Define test executable
-add_executable(testsuite
-  EXCLUDE_FROM_ALL
-    test/japi_test.cc
-)
 
-target_compile_options(testsuite PUBLIC "-pthread")
+  # Define test executable
+  add_executable(testsuite test/japi_test.cc)
 
-target_link_libraries(testsuite
-  gtest_main
-  japi
-)
+  target_compile_options(testsuite PUBLIC "-pthread")
 
-# Include directories
-target_include_directories(testsuite
-  PUBLIC
-    include/
-    src/
-    ${JSONC_INCLUDE_DIRS}
-)
+  target_link_libraries(testsuite gtest_main japi)
 
-add_custom_target(run_test COMMAND testsuite DEPENDS testsuite)
+  # Include directories
+  target_include_directories(testsuite PUBLIC include/ src/
+                                              ${JSONC_INCLUDE_DIRS})
 
+  # add_custom_target(run_test COMMAND testsuite DEPENDS testsuite)
+  gtest_discover_tests(testsuite)
 ################################
-# Test code coverage #
+  # Test code coverage #
 
-if(CMAKE_BUILD_TYPE MATCHES "Debug")
-  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-  include(${CMAKE_SOURCE_DIR}/cmake/CodeCoverage.cmake)
-  set(COVERAGE_EXCLUDES
-      "doxydir"
-      "/usr/include/*"
-      "googletest/*"
-      "test/*"
-  )
-  append_coverage_compiler_flags()
+  if(CMAKE_BUILD_TYPE MATCHES "Debug")
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+    include(${CMAKE_SOURCE_DIR}/cmake/CodeCoverage.cmake)
+    set(COVERAGE_EXCLUDES "doxydir" "/usr/include/*" "googletest/*" "test/*")
+    append_coverage_compiler_flags()
 
-  setup_target_for_coverage_lcov(NAME coverage EXECUTABLE testsuite)
-endif()
+    setup_target_for_coverage_lcov(NAME coverage EXECUTABLE testsuite)
+  endif()
+endif(LIBJAPI_ENABLE_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,15 +90,19 @@ if(LIBJAPI_ENABLE_TESTING)
                                               ${JSONC_INCLUDE_DIRS})
 
   gtest_discover_tests(testsuite)
-################################
-  # Test code coverage #
 
+################################
+# Test code coverage #
   if(CMAKE_BUILD_TYPE MATCHES "Debug")
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
     include(${CMAKE_SOURCE_DIR}/cmake/CodeCoverage.cmake)
-    set(COVERAGE_EXCLUDES "doxydir" "/usr/include/*" "test/*")
+    set(COVERAGE_EXCLUDES
+        "doxydir"
+        "/usr/include"
+        "_deps/googletest"
+        "test/*"
+    )
     append_coverage_compiler_flags()
-
     setup_target_for_coverage_lcov(NAME coverage EXECUTABLE testsuite)
   endif()
 endif(LIBJAPI_ENABLE_TESTING)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A Makefile is generated. Run 'make' to build the libjapi libraries.
 
     $ make
 
-A shared and a static library is built. Tests are built by default. They can be disabled using the `LIBJAPI_ENABLE_TESTING` variable.
+A shared and a static library is built. Tests are built by default. They can be disabled using the command `cmake -DLIBJAPI_ENABLE_TESTING=FALSE ../` variable.
 
 To run the internal tests run
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ A Makefile is generated. Run 'make' to build the libjapi libraries.
 
     $ make
 
-A shared and a static library is built.
+A shared and a static library is built. Tests are built by default. They can be disabled using the `LIBJAPI_ENABLE_TESTING` variable.
 
 To run the internal tests run
 
-    $ make run_test
+    $ ctest
 
 ## Demo
 You can clone the [demo project](https://git01.iis.fhg.de/ks-ip-lib/software/libjapi-demo), with examples for all features from the repository listed below:


### PR DESCRIPTION
Tests can now be enabled and disabled by a CMAKE variable. Also, googletest is always fetched as the system wide installation can cause linker issues that are ugly to resolve.